### PR TITLE
Add week of month to format

### DIFF
--- a/scripts/build/flatten.ts
+++ b/scripts/build/flatten.ts
@@ -5,8 +5,8 @@ import { readFile, readdir, rmdir, stat, unlink, writeFile } from "fs/promises";
 import { dirname, join, relative, resolve } from "path";
 
 const dirsToRemove = new Set<string>();
-const root = resolve(process.env.PACKAGE_OUTPUT_PATH || "lib");
-const relativeRoot = relative(process.cwd(), root);
+const root = resolve(process.env.PACKAGE_OUTPUT_PATH || "lib").replace(/\\/g, '/');
+const relativeRoot = relative(process.cwd(), root).replace(/\\/g, '/');
 
 async function main() {
   return getFiles(relativeRoot)
@@ -14,12 +14,12 @@ async function main() {
       Promise.all(
         files.map(async (filePath) => {
           const content = await readFile(filePath, "utf-8");
-          const newFilePath = getNewPath(filePath);
+          const newFilePath = getNewPath(filePath).replace(/\\/g, '/');
           const isCJS = /\.cjs$/.test(filePath);
           const replaceRE = isCJS ? /require\("([^"]+)"\)/g : /from "([^"]+)"/g;
 
           let newContent = content.replace(replaceRE, (_str, relImportPath) => {
-            const newRelImportPath = getNewImportPath(filePath, relImportPath);
+            const newRelImportPath = getNewImportPath(filePath, relImportPath).replace(/\\/g, '/');
             return isCJS
               ? `require("${newRelImportPath}")`
               : `from "${newRelImportPath}"`;
@@ -29,11 +29,11 @@ async function main() {
             newContent = newContent.replace(
               /import\("([^"]+)"\)/g,
               (_str, relImportPath) =>
-                `import("${getNewImportPath(filePath, relImportPath)}")`,
+                `import("${getNewImportPath(filePath, relImportPath).replace(/\\/g, '/')}")`,
             );
 
           // Non-empty dirs won't delete, so we can add all dirs
-          dirsToRemove.add(dirname(filePath));
+          dirsToRemove.add(dirname(filePath).replace(/\\/g, '/'));
 
           if (newFilePath !== filePath)
             return Promise.all([
@@ -54,13 +54,13 @@ async function main() {
 }
 
 function getNewImportPath(filePath: string, relImportPath: string): string {
-  const importPath = resolvePath(filePath, relImportPath);
+  const importPath = resolvePath(filePath, relImportPath).replace(/\\/g, '/');
 
-  const newFilePath = getNewPath(filePath);
-  const newFullImportPath = getNewPath(importPath);
+  const newFilePath = getNewPath(filePath).replace(/\\/g, '/');
+  const newFullImportPath = getNewPath(importPath).replace(/\\/g, '/');
 
   // Determine the relative path between newFilePath and newFullImportPath
-  const newImportPath = relative(dirname(newFilePath), newFullImportPath);
+  const newImportPath = relative(dirname(newFilePath), newFullImportPath).replace(/\\/g, '/');
 
   return newImportPath.startsWith(".") ? newImportPath : "./" + newImportPath;
 }
@@ -75,8 +75,8 @@ function getNewPath(oldPath: string) {
 }
 
 function resolvePath(base: string, relativePath: string) {
-  const baseDir = dirname(base);
-  return join(baseDir, relativePath);
+  const baseDir = dirname(base).replace(/\\/g, '/');
+  return join(baseDir, relativePath).replace(/\\/g, '/');
 }
 
 const ignoreProcess = [new RegExp(`^${relativeRoot}/docs`)];
@@ -86,7 +86,7 @@ async function getFiles(dir: string): Promise<string[]> {
   let allFiles: string[] = [];
 
   for (const file of files) {
-    const fullPath = join(dir, file);
+    const fullPath = join(dir, file).replace(/\\/g, '/');
     const stats = await stat(fullPath);
 
     if (stats.isDirectory()) {

--- a/src/_lib/format/formatters/index.ts
+++ b/src/_lib/format/formatters/index.ts
@@ -83,6 +83,7 @@ type Formatter = (
  */
 
 export const formatters: { [token: string]: Formatter } = {
+  // TODO: Add W format
   // Era
   G: function (date, token, localize) {
     const era: Era = date.getFullYear() > 0 ? 1 : 0;

--- a/src/_lib/format/formatters/index.ts
+++ b/src/_lib/format/formatters/index.ts
@@ -2,6 +2,7 @@ import { getDayOfYear } from "../../../getDayOfYear/index.js";
 import { getISOWeek } from "../../../getISOWeek/index.js";
 import { getISOWeekYear } from "../../../getISOWeekYear/index.js";
 import { getWeek } from "../../../getWeek/index.js";
+import { getWeekOfMonth } from "../../../getWeekOfMonth/index.js";
 import { getWeekYear } from "../../../getWeekYear/index.js";
 import type { LocaleDayPeriod, Localize } from "../../../locale/types.js";
 import type {
@@ -83,7 +84,6 @@ type Formatter = (
  */
 
 export const formatters: { [token: string]: Formatter } = {
-  // TODO: Add W format
   // Era
   G: function (date, token, localize) {
     const era: Era = date.getFullYear() > 0 ? 1 : 0;
@@ -299,6 +299,17 @@ export const formatters: { [token: string]: Formatter } = {
     }
 
     return addLeadingZeros(week, token.length);
+  },
+
+  // Local week of month
+  W: function (date, token, localize, options) {
+    const weekOfMonth = getWeekOfMonth(date, options);
+
+    if (token === "Wo") {
+      return localize.ordinalNumber(weekOfMonth, { unit: "week" });
+    }
+
+    return addLeadingZeros(weekOfMonth, token.length);
   },
 
   // ISO week of year

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -35,7 +35,7 @@ export { formatters, longFormatters };
 //   then the sequence will continue until the end of the string.
 // - . matches any single character unmatched by previous parts of the RegExps
 const formattingTokensRegExp =
-  /[yYQqMLwIdDecihHKkms]o|(\w)\1*|''|'(''|[^'])+('|$)|./g;
+  /[yYQqMLwWIdDecihHKkms]o|(\w)\1*|''|'(''|[^'])+('|$)|./g;
 
 // This RegExp catches symbols escaped by quotes, and also
 // sequences of symbols P, p, and the combinations like `PPPPPPPppppp`

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -133,6 +133,9 @@ export interface FormatOptions
  * | Local week of year              | w       | 1, 2, ..., 53                     |       |
  * |                                 | wo      | 1st, 2nd, ..., 53th               | 7     |
  * |                                 | ww      | 01, 02, ..., 53                   |       |
+ * | Local week of month             | W       | 1, 2, ..., 53                     |       |
+ * |                                 | Wo      | 1st, 2nd, ..., 53th               | 7     |
+ * |                                 | WW      | 01, 02, ..., 53                   |       |
  * | ISO week of year                | I       | 1, 2, ..., 53                     | 7     |
  * |                                 | Io      | 1st, 2nd, ..., 53th               | 7     |
  * |                                 | II      | 01, 02, ..., 53                   | 7     |

--- a/src/format/test.ts
+++ b/src/format/test.ts
@@ -329,6 +329,23 @@ describe("format", () => {
       });
     });
 
+    describe("local week of month", () => {
+      it("works as expected", () => {
+        const date = new Date(1986, 3 /* Apr */, 6);
+        const result = format(date, "W Wo WW");
+        expect(result).toBe("2 2nd 02");
+      });
+
+      it("allows to specify `weekStartsOn` and `firstWeekContainsDate` in options", () => {
+        const date = new Date(1986, 3 /* Apr */, 6);
+        const result = format(date, "W Wo WW", {
+          weekStartsOn: 1,
+          firstWeekContainsDate: 4,
+        });
+        expect(result).toBe("1 1st 01");
+      });
+    });
+
     it("ISO week of year", () => {
       const date = new Date(1986, 3 /* Apr */, 6);
       const result = format(date, "I Io II");


### PR DESCRIPTION
**What**: Add week of month to `format` module.

**Why**: Week of month is not available in the `format` module of `date-fns`. `const result = format(new Date(), 'W');` shows:
![image](https://github.com/user-attachments/assets/2efa0c7c-454f-4f50-8364-556a29445977)

**How**: This PR adds `W`(1), `Wo`(1st), and `WW`(01) formats for week of month by adding functions as well as test cases for development.